### PR TITLE
Mapped types for major gods and map names, rec parser fix

### DIFF
--- a/src/components/recs/rec-tile.tsx
+++ b/src/components/recs/rec-tile.tsx
@@ -5,6 +5,7 @@ import { toast } from "../ui/use-toast";
 import TeamTile from "./team-tile";
 import { useEffect, useState } from "react";
 import { MythRecs as MythRec } from "@/types/MythRecs";
+import { randomMapNameToData } from "@/types/RandomMap";
 
 export default function RecTile({ rec }: { rec: MythRec }) {
   const { gameGuid, playerData, mapName, createdAt } = rec;
@@ -46,6 +47,9 @@ export default function RecTile({ rec }: { rec: MythRec }) {
 
   // TODO - process team data
 
+
+  const mapData = randomMapNameToData(mapName);
+
   return (
     <div>
       {screenSize.width >= 768 ? (
@@ -54,11 +58,11 @@ export default function RecTile({ rec }: { rec: MythRec }) {
             <TeamTile playerData={playerData[1]} /> {/* TODO - make team dynamic */}
             <div>
               <div className="text-center text-xl text-prim font-semibold w-[240px] min-h-2-lines line-clamp-2">
-                Mista 1v1 Fast Mythic Rush
+                {mapData.name}
               </div>
               <Image
-                src={`/maps/${mapName}.png`}
-                alt={mapName}
+                src={mapData.imagePath}
+                alt={mapData.name}
                 width={240}
                 height={240}
               ></Image>

--- a/src/components/recs/rec-tile.tsx
+++ b/src/components/recs/rec-tile.tsx
@@ -58,7 +58,7 @@ export default function RecTile({ rec }: { rec: MythRec }) {
             <TeamTile playerData={playerData[1]} /> {/* TODO - make team dynamic */}
             <div>
               <div className="text-center text-xl text-prim font-semibold w-[240px] min-h-2-lines line-clamp-2">
-                {mapData.name}
+                Mista 1v1 Fast Mythic
               </div>
               <Image
                 src={mapData.imagePath}

--- a/src/components/recs/team-tile.tsx
+++ b/src/components/recs/team-tile.tsx
@@ -1,15 +1,14 @@
-import { MajorGods, MajorGodsPortraitPath } from "@/types/MajorGods";
+import { majorGodIndexToData } from "@/types/MajorGods";
 import { IPlayerData } from "@/types/MythRecs";
 import Image from "next/image";
 
 export default function TeamTile({ playerData }: { playerData: IPlayerData }) {
   const { name, civ } = playerData;
-  const godName = MajorGods[civ];
-  const godPortraitPath = MajorGodsPortraitPath[godName];
+  const godData = majorGodIndexToData(civ);
   return (
     <div className="flex flex-col items-center my-auto px-2 w-32">
       <Image
-        src={godPortraitPath}
+        src={godData.portraitPath}
         alt={"super cool god description"}
         width={64}
         height={64}

--- a/src/types/MajorGods.ts
+++ b/src/types/MajorGods.ts
@@ -1,29 +1,76 @@
-export enum MajorGods {
-  Zeus = 1, 
-  Hades = 2,
-  Poseidon = 3,
-  Ra = 4,
-  Isis = 5,
-  Set = 6,
-  Thor = 7,
-  Odin = 8,
-  Loki = 9,
-  Kronos = 10,
-  Oranos = 11,
-  Gaia = 12,
+
+interface MajorGodData
+{
+    name: string,
+    portraitPath: string,
 }
 
-export const MajorGodsPortraitPath: { [key: string]: string } = {
-  Zeus: "/gods/greeks/major-gods/zeus_icon.png",
-  Poseidon: "/gods/greeks/major-gods/poseidon_icon.png",
-  Hades: "/gods/greeks/major-gods/hades_icon.png",
-  Isis: "/gods/egyptians/major-gods/isis_icon.png",
-  Ra: "/gods/egyptians/major-gods/ra_icon.png",
-  Set: "/gods/egyptians/major-gods/set_icon.png",
-  Odin: "/gods/norse/major-gods/odin_icon.png",
-  Thor: "/gods/norse/major-gods/thor_icon.png",
-  Loki: "/gods/norse/major-gods/loki_icon.png",
-  Oranos: "/gods/atlanteans/major-gods/oranos_icon.png",
-  Kronos: "/gods/atlanteans/major-gods/kronos_icon.png",
-  Gaia: "/gods/atlanteans/major-gods/gaia_icon.png",
-};
+const UNKNOWN_PORTRAIT_PATH =  "/gods/greeks/major-gods/zeus_icon.png"; // TODO use the random ? icon
+
+const MajorGodsByIndex = new Map<number, MajorGodData>([
+    [0, {
+        name: "Nature",
+        portraitPath: UNKNOWN_PORTRAIT_PATH,
+    }],
+    [1, {
+        name: "Zeus",
+        portraitPath: "/gods/greeks/major-gods/zeus_icon.png",
+    }],
+    [2, {
+        name: "Hades",
+        portraitPath: "/gods/greeks/major-gods/hades_icon.png",
+    }],
+    [3, {
+        name: "Poseidon",
+        portraitPath: "/gods/greeks/major-gods/poseidon_icon.png",
+    }],
+    [4, {
+        name: "Ra",
+        portraitPath: "/gods/egyptians/major-gods/ra_icon.png",
+    }],
+    [5, {
+        name: "Isis",
+        portraitPath: "/gods/egyptians/major-gods/isis_icon.png",
+    }],
+    [6, {
+        name: "Set",
+        portraitPath: "/gods/egyptians/major-gods/set_icon.png",
+    }],
+    [7, {
+        name: "Thor",
+        portraitPath: "/gods/norse/major-gods/thor_icon.png",
+    }],
+    [8, {
+        name: "Odin",
+        portraitPath: "/gods/norse/major-gods/odin_icon.png",
+    }],
+    [9, {
+        name: "Loki",
+        portraitPath: "/gods/norse/major-gods/loki_icon.png",
+    }],
+    [10, {
+        name: "Kronos",
+        portraitPath: "/gods/atlantean/major-gods/kronos_icon.png",
+    }],
+    [11, {
+        name: "Oranos",
+        portraitPath: "/gods/atlantean/major-gods/oranos_icon.png",
+    }],
+    [12, {
+        name: "Gaia",
+        portraitPath: "/gods/atlantean/major-gods/gaia_icon.png",
+    }],
+]);
+
+export function majorGodIndexToData(index: number): MajorGodData
+{
+    let data = MajorGodsByIndex.get(index);
+    if (data === undefined)
+    {
+        return {
+            name: `Unknown ${index}`,
+            portraitPath: UNKNOWN_PORTRAIT_PATH,
+        }
+    }
+    return data;
+}

--- a/src/types/RandomMap.ts
+++ b/src/types/RandomMap.ts
@@ -1,0 +1,271 @@
+interface RandomMapData
+{
+    name: string,
+    imagePath: string,
+    isWater: boolean,
+}
+
+const UNKNOWN_MAP_IMAGE_PATH =  "/maps/the_unknown.png"; // TODO use the random ? icon
+
+const RandomMapDataMap = new Map<string, RandomMapData>([
+    ["acropolis", 
+    {
+        name: "Acropolis",
+        imagePath: "/maps/acropolis.png",
+        isWater: false,
+    }],
+    ["air", 
+    {
+        name: "Aïr",
+        imagePath: "/maps/air.png",
+        isWater: false,
+    }],
+    ["alfheim", 
+    {
+        name: "Alfheim",
+        imagePath: "/maps/alfheim.png",
+        isWater: false,
+    }],
+    ["anatolia", 
+    {
+        name: "Anatolia",
+        imagePath: "/maps/anatolia.png",
+        isWater: true,
+    }],
+    ["archipelago", 
+    {
+        name: "Archipelago",
+        imagePath: "/maps/archipelago.png",
+        isWater: true,
+    }],
+    ["arena", 
+    {
+        name: "Arena",
+        imagePath: "/maps/arena.png",
+        isWater: false,
+    }],
+    ["black_sea", 
+    {
+        name: "Black Sea",
+        imagePath: "/maps/black_sea.png",
+        isWater: true,
+    }],
+    ["blue_lagoon", 
+    {
+        name: "Blue Lagoon",
+        imagePath: "/maps/blue_lagoon.png",
+        isWater: false,
+    }],
+    ["elysium", 
+    {
+        name: "Elysium",
+        imagePath: "/maps/elysium.png",
+        isWater: false,
+    }],
+    ["erebus", 
+    {
+        name: "Erebus",
+        imagePath: "/maps/erebus.png",
+        isWater: false,
+    }],
+    ["ghost_lake", 
+    {
+        name: "Ghost Lake",
+        imagePath: "/maps/ghost_lake.png",
+        isWater: false,
+    }],
+    ["giza", 
+    {
+        name: "Giza",
+        imagePath: "/maps/giza.png",
+        isWater: false,
+    }],
+    ["gold_rush", 
+    {
+        name: "Gold Rush",
+        imagePath: "/maps/gold_rush.png",
+        isWater: false,
+    }],
+    ["highland", 
+    {
+        name: "Highland",
+        imagePath: "/maps/highland.png",
+        isWater: true,
+    }],
+    ["ironwood", 
+    {
+        name: "Ironwood",
+        imagePath: "/maps/ironwood.png",
+        isWater: false,
+    }],
+    ["islands", 
+    {
+        name: "Islands",
+        imagePath: "/maps/islands.png",
+        isWater: true,
+    }],
+    ["jotunheim", 
+    {
+        name: "Jotunheim",
+        imagePath: "/maps/jotunheim.png",
+        isWater: false,
+    }],
+    ["kerlaugar", 
+    {
+        name: "Kerlaugar",
+        imagePath: "/maps/kerlaugar.png",
+        isWater: true,
+    }],
+    ["land_unknown", 
+    {
+        name: "Land Unknown",
+        imagePath: "/maps/land_unknown.png",
+        isWater: false,
+    }],
+    ["marsh", 
+    {
+        name: "Marsh",
+        imagePath: "/maps/marsh.png",
+        isWater: false,
+    }],
+    ["mediterranean", 
+    {
+        name: "Mediterranean",
+        imagePath: "/maps/mediterranean.png",
+        isWater: true,
+    }],
+    ["megalopolis", 
+    {
+        name: "Megalopolis",
+        imagePath: "/maps/megalopolis.png",
+        isWater: false,
+    }],
+    ["midgard", 
+    {
+        name: "Midgard",
+        imagePath: "/maps/midgard.png",
+        isWater: true,
+    }],
+    ["mirage", 
+    {
+        name: "Mirage",
+        imagePath: "/maps/mirage.png",
+        isWater: false,
+    }],
+    ["mirkwood", 
+    {
+        name: "Mirkwood",
+        imagePath: "/maps/mirkwood.png",
+        isWater: false,
+    }],
+    ["mount_olympus", 
+    {
+        name: "Mount Olympus",
+        imagePath: "/maps/mount_olympus.png",
+        isWater: false,
+    }],
+    ["muspellheim", 
+    {
+        name: "Muspellheim",
+        imagePath: "/maps/muspellheim.png",
+        isWater: false,
+    }],
+    ["nile_shallows", 
+    {
+        name: "Nile Shallows",
+        imagePath: "/maps/nile_shallows.png",
+        isWater: false,
+    }],
+    ["nomad", 
+    {
+        name: "Nomad",
+        imagePath: "/maps/nomad.png",
+        isWater: false,
+    }],
+    ["oasis", 
+    {
+        name: "Oasis",
+        imagePath: "/maps/oasis.png",
+        isWater: false,
+    }],
+    ["river_nile", 
+    {
+        name: "River Nile",
+        imagePath: "/maps/river_nile.png",
+        isWater: true,
+    }],
+    ["river_styx", 
+    {
+        name: "River Styx",
+        imagePath: "/maps/river_styx.png",
+        isWater: true,
+    }],
+    ["savannah", 
+    {
+        name: "Savannah",
+        imagePath: "/maps/savannah.png",
+        isWater: false,
+    }],
+    ["sea_of_worms", 
+    {
+        name: "Sea of Worms",
+        imagePath: "/maps/sea_of_worms.png",
+        isWater: true,
+    }],
+    ["team_migration", 
+    {
+        name: "Team Migration",
+        imagePath: "/maps/team_migration.png",
+        isWater: true,
+    }],
+    ["the_unknown", 
+    {
+        name: "The Unknown",
+        imagePath: "/maps/the_unknown.png",
+        isWater: true,
+    }],
+    ["tiny", 
+    {
+        name: "Tiny",
+        imagePath: "/maps/tiny.png",
+        isWater: false,
+    }],
+    ["tundra", 
+    {
+        name: "Tundra",
+        imagePath: "/maps/tundra.png",
+        isWater: false,
+    }],
+    ["valley_of_kings", 
+    {
+        name: "Valley of Kings",
+        imagePath: "/maps/valley_of_kings.png",
+        isWater: false,
+    }],
+    ["vinlandsaga", 
+    {
+        name: "Vinlandsaga",
+        imagePath: "/maps/vinlandsaga.png",
+        isWater: true,
+    }],
+    ["watering_hole", 
+    {
+        name: "Watering Hole",
+        imagePath: "/maps/watering_hole.png",
+        isWater: false,
+    }],
+])
+
+export function randomMapNameToData(mapName: string): RandomMapData
+{
+    let data = RandomMapDataMap.get(mapName);
+    if (data === undefined)
+    {
+        return {
+            name: mapName,
+            imagePath: UNKNOWN_MAP_IMAGE_PATH,
+            isWater: false,
+        };
+    }
+    return data;
+}


### PR DESCRIPTION
Implemented a mapped approach for looking up major gods and random maps, notably these have the advantage of handling values outside expected ones - which in the case of maps unexpected values would otherwise produce links to bad images.

I missed a zero when writing the max decompression buffer size, which is probably why that rec was failing earlier. In any case, it gets written to console.error now.