### PR TITLE
Recparser: deeper team ID fetching, use error enum

### DIFF
--- a/src/server/controllers/upload-rec-controller.ts
+++ b/src/server/controllers/upload-rec-controller.ts
@@ -28,9 +28,6 @@ export default async function uploadRec(
   const recGameMetadata: RecordedGameMetadata = await parseRecordedGameMetadata(
     file
   );
-  if (recGameMetadata.gameNumPlayers > 2) {
-    throw new Error("Only 2 player games are supported");
-  }
   const mappedRecGameMetadata = mapRecGameMetadata(recGameMetadata); //cleanup the data
 
   // 2) save file to mongo, if game guid doesn't already exists

--- a/src/server/recParser.ts
+++ b/src/server/recParser.ts
@@ -150,7 +150,8 @@ async function parseMetadataFromDecompressedRecordedGame(decompressed: Buffer): 
     // Check vs 8 (rather than 0) to make sure trying to go backwards to get to the key count can't give also give a negative offset
     if (metadataOffset < 8)
     {
-        if (decompressed.indexOf(encodeUtf16("benchmark")) < 650)
+        const benchmarkIndex = decompressed.indexOf(encodeUtf16("benchmark"));
+        if (benchmarkIndex < 650 && benchmarkIndex > 0)
         {
             throw new Error(Errors.GAME_IS_BENCHMARK, {cause:"This looks like a recorded game of the benchmark - it is not a multiplayer game!"});
         }

--- a/src/types/RecordedGameParser.ts
+++ b/src/types/RecordedGameParser.ts
@@ -289,7 +289,3 @@ export interface RecordedGameMetadata extends Record<typeof RecordedGameMetadata
      */
     teams: number[][],
 }
-
-export class RecParseError extends Error
-{
-}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,8 +1,15 @@
 export enum Errors {
   UNIQUE_KEY_VIOLATION = "UNIQUE_KEY_VIOLATION",
-  UNSUPPORTED_GAME_SIZE = "UNSUPPORTED_GAME_SIZE",
   ERROR_UPLOADING_REC = "ERROR_UPLOADING_REC",
   ERROR_DOWNLOADING_REC = "ERROR_DOWNLOADING_REC",
   ERROR_FETCHING_RECS = "ERROR_FETCHING_RECS",
   ERROR_INCREMENTING_DOWNLOAD_COUNT = "ERROR_INCREMENTING_DOWNLOAD_COUNT",
+
+  // Rec parser outcomes
+  UNSUPPORTED_GAME_SIZE = "UNSUPPORTED_GAME_SIZE",                // Currently limiting to 1v1
+  GAME_IS_BENCHMARK = "GAME_IS_BENCHMARK",                        // Game looks like a rec of the benchmark
+  FILE_IS_NOT_A_RECORDED_GAME = "FILE_IS_NOT_A_RECORDED_GAME",    // Game doesn't look like an AoM file
+  GAME_HAS_AI_PLAYERS = "GAME_HAS_AI_PLAYERS",                    // Game has any AI players in it
+  NOT_A_MULTIPLAYER_GAME = "NOT_A_MULTIPLAYER_GAME",              // Rec doesn't have metadata and doesn't look like a benchmark
+  PARSER_INTERNAL_ERROR = "PARSER_INTERNAL_ERROR",                // Thrown by other (technical) parser errors
 }


### PR DESCRIPTION
Team ID parsing is the same as the previous PR. I've hopefully successfully cleaned the branch history so it's now just 1 commit on top of the current state without being mixed in with all the troubled stuff.

Errors are now using the errors.ts enum with `cause` field filled in for some types, though there's currently no mechanism to send that back or anything the response to the upload request.