### PR TITLE
Parser: versioning, team sizes as easily accessible string, and (hopefully) game length

### DIFF
--- a/src/db/mongo/schemas/recordedGame/RecordedGameSchema.ts
+++ b/src/db/mongo/schemas/recordedGame/RecordedGameSchema.ts
@@ -23,6 +23,7 @@ const RecordedGameSchema = new Schema(
     teamsFormatString: {type: String, required: false, default:""},
     parsedAt: { type: Date, required: true},
     version: { type: Number, required: false, default: 0},
+    gameLength: {type: Number, required: false, default: 0},
     teams: { type: [[Number]]},
     ...recMetadataSchemaHelper(RecordedGameMetadataBooleansRequired, Boolean, false, true),
     ...recMetadataSchemaHelper(RecordedGameMetadataStringsRequired, String, "", true),

--- a/src/db/mongo/schemas/recordedGame/RecordedGameSchema.ts
+++ b/src/db/mongo/schemas/recordedGame/RecordedGameSchema.ts
@@ -20,6 +20,7 @@ const RecordedGameSchema = new Schema(
     playerData: { type: [PlayerDataSchema], required: true },
     buildNumber: { type: Number, required: true, default: 0 },
     buildString: { type: String, required: true, default: "" },
+    teamsFormatString: {type: String, required: false, default:""},
     parsedAt: { type: Date, required: true},
     teams: { type: [[Number]]},
     ...recMetadataSchemaHelper(RecordedGameMetadataBooleansRequired, Boolean, false, true),

--- a/src/db/mongo/schemas/recordedGame/RecordedGameSchema.ts
+++ b/src/db/mongo/schemas/recordedGame/RecordedGameSchema.ts
@@ -22,6 +22,7 @@ const RecordedGameSchema = new Schema(
     buildString: { type: String, required: true, default: "" },
     teamsFormatString: {type: String, required: false, default:""},
     parsedAt: { type: Date, required: true},
+    version: { type: Number, required: false, default: 0},
     teams: { type: [[Number]]},
     ...recMetadataSchemaHelper(RecordedGameMetadataBooleansRequired, Boolean, false, true),
     ...recMetadataSchemaHelper(RecordedGameMetadataStringsRequired, String, "", true),

--- a/src/server/recParser.ts
+++ b/src/server/recParser.ts
@@ -288,6 +288,12 @@ async function parseMetadataFromDecompressedRecordedGame(decompressed: Buffer): 
 
     parseTeams(typedOutput, decompressed, stringKeysToUnsafeStrings);
     typedOutput.version = REC_PARSER_STRUCTURE_VERSION;
+    // Hard to be sure, but the stuff at the end of the file looks like it might be game orders blocks
+    // 5 bytes before the end of the file is the highest indexed one - and from comparing recs to their cast videos
+    // it looks like this number divided by 20 is the game length in seconds
+    const numGameEntriesOffset = decompressed.length - 5;
+    const numGameEntries = view.getUint32(numGameEntriesOffset, true);
+    typedOutput.gameLength = numGameEntries / 20;
     return typedOutput;
 }
 

--- a/src/server/recParser.ts
+++ b/src/server/recParser.ts
@@ -4,6 +4,8 @@ import { Errors } from "@/utils/errors";
 import { promisify } from "util";
 import { CompressCallback, inflate, InputType } from "zlib";
 
+const REC_PARSER_STRUCTURE_VERSION = 1;
+
 // The max allowed decomprssed size of files that are passed as "recorded games".
 // This needs to be limited to avoid someone uploading a huge zlib decompression bomb and trying to decompress the entire thing in memory
 const RECORDED_GAME_MAX_BYTES_TO_DECOMPRESS = 500000000; // 50mb
@@ -285,6 +287,7 @@ async function parseMetadataFromDecompressedRecordedGame(decompressed: Buffer): 
     }
 
     parseTeams(typedOutput, decompressed, stringKeysToUnsafeStrings);
+    typedOutput.version = REC_PARSER_STRUCTURE_VERSION;
     return typedOutput;
 }
 

--- a/src/server/recParser.ts
+++ b/src/server/recParser.ts
@@ -278,7 +278,7 @@ async function parseMetadataFromDecompressedRecordedGame(decompressed: Buffer): 
     {
         throw new Error(Errors.GAME_HAS_AI_PLAYERS);
     }
-
+    
     if (typedOutput.gameNumPlayers > 2)
     {
         throw new Error(Errors.UNSUPPORTED_GAME_SIZE, {cause:`Currently uploads are limited to 1v1s only - this game has ${typedOutput.gameNumPlayers} players!`});
@@ -423,5 +423,11 @@ function parseTeams(output: RecordedGameMetadata, decompressed: Buffer, stringKe
             output.teams[index].push(playerData.id);
         }
     }
+
+    if (output.teams.length < 2)
+    {
+        throw new Error(Errors.UNSUPPORTED_GAME_SIZE, {cause: `The players in this game seem to only be arranged into ${output.teams.length} teams(s).`});
+    }
     
+    output.teamsFormatString = output.teams.map((teamArray) => teamArray.length).join("v");
 }

--- a/src/types/RecordedGameParser.ts
+++ b/src/types/RecordedGameParser.ts
@@ -293,4 +293,10 @@ export interface RecordedGameMetadata extends Record<typeof RecordedGameMetadata
      *  Eg: "1v1", "3v3", "1v2v3"...
      */
     teamsFormatString?: string,
+
+    /**
+     * Version of this structure.
+     * Undefined = earlier than its existence
+     */
+    version?: number,
 }

--- a/src/types/RecordedGameParser.ts
+++ b/src/types/RecordedGameParser.ts
@@ -299,4 +299,10 @@ export interface RecordedGameMetadata extends Record<typeof RecordedGameMetadata
      * Undefined = earlier than its existence
      */
     version?: number,
+
+    /**
+     * The game length, in seconds.
+     * This will most likely have a decimal component as well.
+     */
+    gameLength?: number,
 }

--- a/src/types/RecordedGameParser.ts
+++ b/src/types/RecordedGameParser.ts
@@ -288,4 +288,9 @@ export interface RecordedGameMetadata extends Record<typeof RecordedGameMetadata
      * Eg: a 3v3 with p1/2/3 vs p4/5/6 = [[1, 2, 3], [4, 5, 6]]
      */
     teams: number[][],
+    /**
+     *  A string that lists the sizes of all the teams in the game. 
+     *  Eg: "1v1", "3v3", "1v2v3"...
+     */
+    teamsFormatString?: string,
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -6,7 +6,7 @@ export enum Errors {
   ERROR_INCREMENTING_DOWNLOAD_COUNT = "ERROR_INCREMENTING_DOWNLOAD_COUNT",
 
   // Rec parser outcomes
-  UNSUPPORTED_GAME_SIZE = "UNSUPPORTED_GAME_SIZE",                // Currently limiting to 1v1
+  UNSUPPORTED_GAME_SIZE = "UNSUPPORTED_GAME_SIZE",                // Currently limiting to 1v1. Also thrown if there seems to be only one team in the data
   GAME_IS_BENCHMARK = "GAME_IS_BENCHMARK",                        // Game looks like a rec of the benchmark
   FILE_IS_NOT_A_RECORDED_GAME = "FILE_IS_NOT_A_RECORDED_GAME",    // Game doesn't look like an AoM file
   GAME_HAS_AI_PLAYERS = "GAME_HAS_AI_PLAYERS",                    // Game has any AI players in it


### PR DESCRIPTION
As we talked about a few days ago:

1. Added a version field to the parser output, so now old values in the DB can be identified
2. Added `teamsFormatString` that's "1v1" "1v1v2v3" or whatever the sizes of the teams in the game are. The name of this could maybe use work but I couldn't think of anything better quickly.
3. Added slightly experimental game duration parsing. I say this because without a functioning build to make new recs on it's hard to be sure that this is really correct. At the end of the recorded game data there is what I assume are the actual instructions, in little lists - it looks like the game makes list entries 20 times a second regardless of whether anything actually happens in them. At least, digging the game duration this way lines up with the videos of the actual games cast on Youtube.