### PR TITLE
add user profile stats by god

### DIFF
--- a/src/app/api/data/builds/route.ts
+++ b/src/app/api/data/builds/route.ts
@@ -1,0 +1,22 @@
+import { BuildModel } from "@/db/mongo/model/BuildNumber";
+import getMongoClient from "@/db/mongo/mongo-client";
+
+export const GET = async function GET(req: Request) {
+  try {
+    await getMongoClient();
+    const builds = await BuildModel.find({}, "description");
+    const buildDescriptions = builds.map((build) => build.description);
+
+    return new Response(JSON.stringify(buildDescriptions), {
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "public, max-age=86400, stale-while-revalidate=86400",
+      },
+    });
+  } catch (error: any) {
+    return new Response(
+      JSON.stringify({ error: "Error fetching build descriptions" }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+};

--- a/src/app/api/data/game_modes/route.ts
+++ b/src/app/api/data/game_modes/route.ts
@@ -1,0 +1,20 @@
+import { MatchModel } from "@/db/mongo/model/MatchModel";
+import getMongoClient from "@/db/mongo/mongo-client";
+
+export const GET = async function GET(req: Request) {
+  try {
+    await getMongoClient();
+    const gameModes = await MatchModel.distinct("gameMode");
+    return new Response(JSON.stringify(gameModes), {
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "public, max-age=86400, stale-while-revalidate=86400",
+      },
+    });
+  } catch (error: any) {
+    return new Response(
+      JSON.stringify({ error: "Failed to fetch game modes" }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+};

--- a/src/app/api/stats/user/gods/route.ts
+++ b/src/app/api/stats/user/gods/route.ts
@@ -1,0 +1,22 @@
+import { getUserGodStats, IFetchUserGodStatsParams } from "./service";
+
+export const GET = async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const params: IFetchUserGodStatsParams = {
+      playerId: parseInt(searchParams.get("playerId") || "0", 10),
+      patchDescription: searchParams.get("patchDescription") || undefined,
+      civilization: searchParams.get("civilization")
+        ? parseInt(searchParams.get("civilization")!, 10)
+        : undefined,
+      gameMode: searchParams.get("gameMode") || undefined,
+    };
+    const userGodStats = await getUserGodStats(params);
+    return new Response(JSON.stringify(userGodStats));
+  } catch (error: any) {
+    return new Response(
+      JSON.stringify({ error: "Error fetching user god stats" }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+};

--- a/src/app/api/stats/user/gods/service.ts
+++ b/src/app/api/stats/user/gods/service.ts
@@ -1,0 +1,145 @@
+import { BuildModel } from "@/db/mongo/model/BuildNumber";
+import { MatchModel } from "@/db/mongo/model/MatchModel";
+import getMongoClient from "@/db/mongo/mongo-client";
+
+export interface IFetchUserGodStatsParams {
+  playerId: number;
+  patchDescription?: string;
+  civilization?: number;
+  gameMode?: string;
+}
+
+async function getPatchDates(patchDescription: string) {
+  await getMongoClient();
+  const builds = await BuildModel.find().sort({ releaseDate: 1 });
+  const patchIndex = builds.findIndex(
+    (build) => build.description === patchDescription
+  );
+
+  if (patchIndex === -1) {
+    throw new Error("Patch description not found");
+  }
+
+  const startDate = builds[patchIndex].releaseDate;
+  const endDate =
+    patchIndex < builds.length - 1
+      ? builds[patchIndex + 1].releaseDate
+      : new Date();
+
+  return { startDate, endDate };
+}
+
+export async function getUserGodStats(params: IFetchUserGodStatsParams) {
+  await getMongoClient();
+  const { playerId, patchDescription, civilization, gameMode } = params;
+  let matchQuery: any = {
+    "teams.results.profile_id": playerId,
+  };
+
+  if (patchDescription) {
+    const { startDate, endDate } = await getPatchDates(patchDescription);
+    matchQuery.matchDate = {
+      $gte: startDate.getTime(),
+      $lt: endDate.getTime(),
+    };
+  }
+
+  if (civilization) {
+    matchQuery["teams.results"] = {
+      $elemMatch: {
+        profile_id: playerId,
+        civilization_id: civilization,
+      },
+    };
+  }
+
+  if (gameMode) {
+    matchQuery.gameMode = gameMode;
+  }
+
+  const matches = await MatchModel.find(matchQuery);
+
+  const godStatsMap = new Map<
+    string,
+    {
+      civilization_id: number;
+      race_id: number;
+      wins: number;
+      losses: number;
+      number_of_games: number;
+    }
+  >();
+
+  for (const match of matches) {
+    const gameMode = match.gameMode;
+    for (const team of match.teams) {
+      for (const result of team.results) {
+        if (result.profile_id === playerId) {
+          const { civilization_id, race_id, resulttype } = result;
+          const key = `${gameMode}-${civilization_id}`;
+          if (!godStatsMap.has(key)) {
+            godStatsMap.set(key, {
+              civilization_id,
+              race_id,
+              wins: 0,
+              losses: 0,
+              number_of_games: 0,
+            });
+          }
+          const godStats = godStatsMap.get(key)!;
+          godStats.number_of_games += 1;
+          if (resulttype === 1) {
+            godStats.wins += 1;
+          } else {
+            godStats.losses += 1;
+          }
+        }
+      }
+    }
+  }
+
+  const totalGames = Array.from(godStatsMap.values()).reduce(
+    (acc, stat) => acc + stat.number_of_games,
+    0
+  );
+
+  const combinedGodStats = new Map<
+    number,
+    {
+      civilization_id: number;
+      race_id: number;
+      total_wins: number;
+      total_games: number;
+    }
+  >();
+
+  // Combine the stats across game modes
+  Array.from(godStatsMap.entries()).forEach(([_, stat]) => {
+    const { civilization_id, race_id, wins, number_of_games } = stat;
+
+    if (!combinedGodStats.has(civilization_id)) {
+      combinedGodStats.set(civilization_id, {
+        civilization_id,
+        race_id,
+        total_wins: 0,
+        total_games: 0,
+      });
+    }
+
+    const combinedStat = combinedGodStats.get(civilization_id)!;
+    combinedStat.total_wins += wins;
+    combinedStat.total_games += number_of_games;
+  });
+
+  const godStatsArray = Array.from(combinedGodStats.values()).map((stat) => {
+    return {
+      civilization_id: stat.civilization_id,
+      race_id: stat.race_id,
+      win_rate: stat.total_wins / stat.total_games,
+      play_rate: stat.total_games / totalGames,
+      number_of_games: stat.total_games,
+    };
+  });
+
+  return godStatsArray;
+}

--- a/src/components/profile/playerGodStats.tsx
+++ b/src/components/profile/playerGodStats.tsx
@@ -362,7 +362,6 @@ export default function PlayerGodStats({ playerId }: PlayerGodStatsProps) {
                       </TableCell>
                       <TableCell>{(god.play_rate * 100).toFixed(2)}%</TableCell>
                       <TableCell>{god.number_of_games}</TableCell>
-                      {patch && <TableCell>{god.patch}</TableCell>}
                     </TableRow>
                   ))}
                 </TableBody>

--- a/src/components/profile/playerGodStats.tsx
+++ b/src/components/profile/playerGodStats.tsx
@@ -1,0 +1,376 @@
+import { useState, useEffect, Key } from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { ArrowUpDown, ArrowUp, ArrowDown, ChevronDown, X } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  listMajorGods,
+  majorGodIndexToData,
+  majorGodNameToIndex,
+} from "@/types/MajorGods";
+import Image from "next/image";
+
+interface GodStats {
+  godData: any;
+  civilization_id: number;
+  win_rate: number;
+  play_rate: number;
+  number_of_games: number;
+  game_mode: string;
+  patch?: string;
+}
+
+interface PlayerGodStatsProps {
+  playerId: string;
+}
+
+export default function PlayerGodStats({ playerId }: PlayerGodStatsProps) {
+  const [sortColumn, setSortColumn] =
+    useState<keyof GodStats>("civilization_id");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
+  const [patch, setPatch] = useState("");
+  const [civilization, setCivilization] = useState("");
+  const [gameMode, setGameMode] = useState("");
+  const [godStats, setGodStats] = useState<GodStats[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const [builds, setBuilds] = useState<string[]>([]);
+  const [gameModes, setGameModes] = useState<string[]>([]);
+
+  const MAJOR_GODS = listMajorGods();
+
+  useEffect(() => {
+    const fetchBuilds = async () => {
+      try {
+        const response = await fetch(`/api/data/builds`);
+        if (!response.ok) {
+          console.log("Failed to fetch builds");
+          throw new Error("Failed to fetch builds");
+        }
+        const data = await response.json();
+        setBuilds(data);
+      } catch (error) {
+        console.error("Error fetching builds:", error);
+      }
+    };
+    fetchBuilds();
+  }, []);
+
+  useEffect(() => {
+    const fetchGameModes = async () => {
+      console.log("Fetching available game modes");
+      try {
+        const response = await fetch(`/api/data/game_modes`);
+        if (!response.ok) {
+          console.log("Failed to fetch game modes");
+          throw new Error("Failed to fetch game modes");
+        }
+        const data = await response.json();
+        console.log("TEST", data);
+        setGameModes(data);
+      } catch (error) {
+        console.error("Error fetching game modes:", error);
+      }
+    };
+    fetchGameModes();
+  }, []);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      console.log("Fetching user god stats");
+      setLoading(true);
+      try {
+        const params = new URLSearchParams({ playerId: playerId.toString() });
+
+        if (patch) {
+          params.append("patchDescription", patch);
+        }
+        if (civilization) {
+          const godIndex = majorGodNameToIndex(civilization);
+          if (godIndex !== undefined) {
+            params.append("civilization", godIndex.toString());
+          }
+        }
+        if (gameMode) {
+          params.append("gameMode", gameMode);
+        }
+
+        const response = await fetch(
+          `/api/stats/user/gods?${params.toString()}`
+        );
+        if (!response.ok) {
+          console.log("Failed to fetch user god stats");
+          throw new Error("Failed to fetch user god stats");
+        }
+        const data = await response.json();
+        console.log("TEST", data);
+        const mappedData = data.map((item: any) => {
+          const godData = majorGodIndexToData(item.civilization_id);
+          return {
+            ...item,
+            godData,
+            patch: item.patch_description,
+          };
+        });
+        setGodStats(mappedData);
+      } catch (error) {
+        console.error("Error fetching user god stats:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [playerId, gameMode, civilization, patch]);
+
+  const sortedGodStats = [...godStats].sort((a, b) => {
+    if (a[sortColumn] < b[sortColumn]) return sortDirection === "asc" ? -1 : 1;
+    if (a[sortColumn] > b[sortColumn]) return sortDirection === "asc" ? 1 : -1;
+    return 0;
+  });
+
+  const handleSort = (column: keyof GodStats) => {
+    if (column === sortColumn) {
+      setSortDirection(sortDirection === "asc" ? "desc" : "asc");
+    } else {
+      setSortColumn(column);
+      setSortDirection("asc");
+    }
+  };
+
+  const SortIcon = ({ column }: { column: keyof GodStats }) => {
+    if (sortColumn !== column) return <ArrowUpDown className="ml-2 h-4 w-4" />;
+    return sortDirection === "asc" ? (
+      <ArrowUp className="ml-2 h-4 w-4" />
+    ) : (
+      <ArrowDown className="ml-2 h-4 w-4" />
+    );
+  };
+
+  const getWinRateColor = (winRate: number) => {
+    if (winRate > 55) return "text-green-700";
+    if (winRate > 52.5) return "text-green-600";
+    if (winRate > 50) return "text-green-500";
+    if (winRate < 45) return "text-red-700";
+    if (winRate < 47.5) return "text-red-600";
+    if (winRate < 50) return "text-red-500";
+    return "";
+  };
+
+  const selectedGod = MAJOR_GODS.find((god) => god.name === civilization);
+
+  return (
+    <Card>
+      <CardContent className="space-y-4 p-6">
+        <div className="flex space-x-4 justify-start">
+          <div className="flex flex-col">
+            <Label htmlFor="patch-dropdown" className="mb-1 text-gold">
+              Patch
+            </Label>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  id="patch-dropdown"
+                  variant="outline"
+                  className="bg-gray-100 dark:bg-gray-700 flex justify-between items-center"
+                >
+                  {patch || "Select Patch"}
+                  <ChevronDown className="ml-2 h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem onSelect={() => setPatch("")}>
+                  <X className="mr-2 h-4 w-4" />
+                  Clear
+                </DropdownMenuItem>
+                {builds.map((build) => (
+                  <DropdownMenuItem
+                    key={build as Key}
+                    onSelect={() => setPatch(build)}
+                  >
+                    {build}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          <div className="flex flex-col">
+            <Label htmlFor="civilization-dropdown" className="mb-1 text-gold">
+              Major God
+            </Label>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  id="civilization-dropdown"
+                  variant="outline"
+                  className="bg-gray-100 dark:bg-gray-700 flex justify-between items-center"
+                >
+                  {selectedGod ? (
+                    <div className="flex items-center">
+                      <Image
+                        src={selectedGod.portraitPath}
+                        alt={selectedGod.name}
+                        width={24}
+                        height={24}
+                        className="mr-2"
+                      />
+                      {selectedGod.name}
+                    </div>
+                  ) : (
+                    "Select Major God"
+                  )}
+                  <ChevronDown className="ml-2 h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem onSelect={() => setCivilization("")}>
+                  <X className="mr-2 h-4 w-4" />
+                  Clear
+                </DropdownMenuItem>
+                {MAJOR_GODS.map((god) => (
+                  <DropdownMenuItem
+                    key={god.name}
+                    onSelect={() => setCivilization(god.name)}
+                  >
+                    <div className="flex items-center">
+                      <Image
+                        src={god.portraitPath}
+                        alt={god.name}
+                        width={24}
+                        height={24}
+                        className="mr-2"
+                      />
+                      {god.name}
+                    </div>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          <div className="flex flex-col">
+            <Label htmlFor="gamemode-dropdown" className="mb-1 text-gold">
+              Game Mode
+            </Label>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  id="gamemode-dropdown"
+                  variant="outline"
+                  className="bg-gray-100 dark:bg-gray-700 flex justify-between items-center"
+                >
+                  {gameMode || "Select Game Mode"}
+                  <ChevronDown className="ml-2 h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem onSelect={() => setGameMode("")}>
+                  <X className="mr-2 h-4 w-4" />
+                  Clear
+                </DropdownMenuItem>
+                {gameModes.map((mode) => (
+                  <DropdownMenuItem
+                    key={mode as Key}
+                    onSelect={() => setGameMode(mode)}
+                  >
+                    {mode}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+
+        <div className="w-[90vw] overflow-x-auto">
+          {loading ? (
+            <div className="flex justify-center items-center h-64">
+              <p>Loading...</p>
+            </div>
+          ) : godStats.length === 0 ? (
+            <div className="flex justify-center items-center h-64">
+              <p>No Games Played</p>
+            </div>
+          ) : (
+            <div style={{ maxHeight: "25vh", overflowY: "auto" }}>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead
+                      onClick={() => handleSort("civilization_id")}
+                      className="cursor-pointer text-gold text-sm"
+                    >
+                      God
+                      <SortIcon column="civilization_id" />
+                    </TableHead>
+                    <TableHead
+                      onClick={() => handleSort("win_rate")}
+                      className="cursor-pointer text-gold text-sm"
+                    >
+                      Win Rate
+                      <SortIcon column="win_rate" />
+                    </TableHead>
+                    <TableHead
+                      onClick={() => handleSort("play_rate")}
+                      className="cursor-pointer text-gold text-sm"
+                    >
+                      Play Rate
+                      <SortIcon column="play_rate" />
+                    </TableHead>
+                    <TableHead
+                      onClick={() => handleSort("number_of_games")}
+                      className="cursor-pointer text-gold text-sm"
+                    >
+                      #Games
+                      <SortIcon column="number_of_games" />
+                    </TableHead>
+                    {patch && (
+                      <TableHead className="text-gold text-sm">Patch</TableHead>
+                    )}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {sortedGodStats.map((god, index) => (
+                    <TableRow key={`${god.civilization_id}-${index}`}>
+                      <TableCell>
+                        <div className="flex items-center">
+                          <Image
+                            src={god.godData.portraitPath}
+                            alt={god.godData.name}
+                            width={24}
+                            height={24}
+                            className="mr-2"
+                          />
+                          <span>{god.godData.name}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell
+                        className={getWinRateColor(god.win_rate * 100)}
+                      >
+                        {(god.win_rate * 100).toFixed(2)}%
+                      </TableCell>
+                      <TableCell>{(god.play_rate * 100).toFixed(2)}%</TableCell>
+                      <TableCell>{god.number_of_games}</TableCell>
+                      {patch && <TableCell>{god.patch}</TableCell>}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/profile/playerGodStats.tsx
+++ b/src/components/profile/playerGodStats.tsx
@@ -335,9 +335,6 @@ export default function PlayerGodStats({ playerId }: PlayerGodStatsProps) {
                       #Games
                       <SortIcon column="number_of_games" />
                     </TableHead>
-                    {patch && (
-                      <TableHead className="text-gold text-sm">Patch</TableHead>
-                    )}
                   </TableRow>
                 </TableHeader>
                 <TableBody>

--- a/src/components/profile/profile.tsx
+++ b/src/components/profile/profile.tsx
@@ -23,6 +23,7 @@ import {
 } from "@radix-ui/react-icons";
 import Loading from "../loading";
 import { Frown } from "lucide-react";
+import PlayerGodStats from "./playerGodStats";
 
 export default function Profile() {
   const [matchHistoryStats, setMatchHistoryStats] = useState<Match[]>([]);
@@ -253,6 +254,21 @@ export default function Profile() {
         )}
       </div>
 
+      <div className="w-full my-4">
+        {loading ? (
+          <div className="space-y-4">
+            <Skeleton className="w-full h-12" />
+            <Skeleton className="w-full h-64" />
+          </div>
+        ) : dataFetched ? (
+          <PlayerGodStats playerId={playerId} />
+        ) : (
+          <div className="text-center text-gray-500 flex flex-col items-center justify-center h-64">
+            <Frown className="text-primary mb-4" size={64} />
+            <p>Failed to load god stats</p>
+          </div>
+        )}
+      </div>
       <Card className="w-full">
         {loading ? (
           <div className="p-4">

--- a/src/types/MajorGods.ts
+++ b/src/types/MajorGods.ts
@@ -19,7 +19,7 @@ export enum MajorGods {
   Kronos = 10,
   Oranos = 11,
   Gaia = 12,
-  Freyr = 13
+  Freyr = 13,
 }
 
 const MajorGodsByIndex = new Map<number, MajorGodData>([
@@ -139,4 +139,13 @@ export function majorGodIndexToData(index: number): MajorGodData {
     };
   }
   return data;
+}
+
+export function majorGodNameToIndex(name: string): number {
+  for (const [index, data] of Array.from(MajorGodsByIndex.entries())) {
+    if (data.name === name) {
+      return index;
+    }
+  }
+  return -1;
 }


### PR DESCRIPTION
Changes:

- Adds `/api/data/builds` and `/api/data/game_modes` (avoids us having to maintain hard-coded values, and has the upshot of having the `game_modes` list used in the filter only include `game_modes` that have been played) - added cache control headers to this so we don't overfetch on each page reload.
- Adds `/api/stats/users/gods` + service
- Adds `majorGodNameToIndex` function
- Adds the `playerGodStats.tsx` component

How it works:
- We use the `Matches` collection and Mongo filters to pull back the appropriate Match info (all matches for a provided profileId, with some combination of civ, patch and major god) - we then manipulate the returned data to get w/l and play rates, combined across game modes.
- I also opted **not** to centralise the fetch logic in `profile.tsx` (like the other components), it looked pretty monolithic already.

How it looks:
![image](https://github.com/user-attachments/assets/53038794-de21-4b13-a47c-d0410944d577)


Extensions:
- I'd probably add a "Frequently Played" table in the future, but didn't want this PR to be too big as it's already getting big.

Closes #107 