### PR TITLE
Fix mobile player gods and teams

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev-network": "next dev -p 3000 --hostname 0.0.0.0",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/src/components/profile/playerGodStats.tsx
+++ b/src/components/profile/playerGodStats.tsx
@@ -174,8 +174,8 @@ export default function PlayerGodStats({ playerId }: PlayerGodStatsProps) {
 
   return (
     <Card>
-      <CardContent className="space-y-4 p-6">
-        <div className="flex flex-wrap space-x-2 justify-start">
+      <CardContent className="p-6 sm:space-x-2">
+        <div className="flex flex-wrap  justify-start gap-2">
           <div className="flex flex-col">
             <Label htmlFor="patch-dropdown" className="mb-1 text-gold">
               Patch

--- a/src/components/profile/playerGodStats.tsx
+++ b/src/components/profile/playerGodStats.tsx
@@ -175,7 +175,7 @@ export default function PlayerGodStats({ playerId }: PlayerGodStatsProps) {
   return (
     <Card>
       <CardContent className="space-y-4 p-6">
-        <div className="flex space-x-4 justify-start">
+        <div className="flex flex-wrap space-x-2 justify-start">
           <div className="flex flex-col">
             <Label htmlFor="patch-dropdown" className="mb-1 text-gold">
               Patch
@@ -303,7 +303,7 @@ export default function PlayerGodStats({ playerId }: PlayerGodStatsProps) {
               <p>No Games Played</p>
             </div>
           ) : (
-            <div style={{ maxHeight: "25vh", overflowY: "auto" }}>
+            <div>
               <Table>
                 <TableHeader>
                   <TableRow>

--- a/src/components/profile/playerGodStats.tsx
+++ b/src/components/profile/playerGodStats.tsx
@@ -293,7 +293,7 @@ export default function PlayerGodStats({ playerId }: PlayerGodStatsProps) {
           </div>
         </div>
 
-        <div className="overflow-x-auto">
+        <div>
           {loading ? (
             <div className="flex justify-center items-center h-64">
               <p>Loading...</p>

--- a/src/components/profile/playerInfo.tsx
+++ b/src/components/profile/playerInfo.tsx
@@ -30,7 +30,7 @@ export function PlayerInfo({
   const defaultTab = gameTypes[0]?.toString() || "1";
 
   return (
-    <Tabs defaultValue={defaultTab}>
+    <Tabs defaultValue={defaultTab} className="w-full">
       <Card className="border-0 w-full bg-gradient-to-br from-gray-900 to-gray-800 text-white shadow-xl min-w-96 ">
         <CardContent className="sm:p-4">
           <div className="flex flex-col sm:flex-row items-center sm:items-start gap-4">

--- a/src/components/profile/playerInfo.tsx
+++ b/src/components/profile/playerInfo.tsx
@@ -32,7 +32,7 @@ export function PlayerInfo({
   return (
     <Tabs defaultValue={defaultTab} className="w-full">
       <Card className="border-0 w-full bg-gradient-to-br from-gray-900 to-gray-800 text-white shadow-xl min-w-96 ">
-        <CardContent className="p-4">
+        <CardContent className="sm:p-4">
           <div className="flex flex-col sm:flex-row items-center sm:items-start gap-4">
             <div className="flex-shrink-0 flex flex-col items-center self-center">
               <ProfileAvatar steamProfile={steamProfile} loading={loading} />

--- a/src/components/profile/playerInfo.tsx
+++ b/src/components/profile/playerInfo.tsx
@@ -31,7 +31,7 @@ export function PlayerInfo({
 
   return (
     <Tabs defaultValue={defaultTab} className="w-full">
-      <Card className="border-0 w-full bg-gradient-to-br from-gray-900 to-gray-800 text-white shadow-xl min-w-96 ">
+      <Card className="pt-5 sm:pt-0 border-0 w-full bg-gradient-to-br from-gray-900 to-gray-800 text-white shadow-xl min-w-96 ">
         <CardContent className="sm:p-4">
           <div className="flex flex-col sm:flex-row items-center sm:items-start gap-4">
             <div className="flex-shrink-0 flex flex-col items-center self-center">

--- a/src/components/profile/playerInfo.tsx
+++ b/src/components/profile/playerInfo.tsx
@@ -30,7 +30,7 @@ export function PlayerInfo({
   const defaultTab = gameTypes[0]?.toString() || "1";
 
   return (
-    <Tabs defaultValue={defaultTab} className="w-full">
+    <Tabs defaultValue={defaultTab}>
       <Card className="border-0 w-full bg-gradient-to-br from-gray-900 to-gray-800 text-white shadow-xl min-w-96 ">
         <CardContent className="sm:p-4">
           <div className="flex flex-col sm:flex-row items-center sm:items-start gap-4">

--- a/src/components/profile/statCard.tsx
+++ b/src/components/profile/statCard.tsx
@@ -27,7 +27,7 @@ export default function StatCard({ playerStats }: IStatCardProps) {
       <h2 className="text-2xl font-bold mb-4 text-gold">
         {LeaderboardTypeNames[Number(leaderboard_id)]}
       </h2>
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-2 md:gap-4">
         <StatItem label="Rank" value={`#${rank}`} />
         <StatItem label="Elo" value={String(rating)} />
         <StatItem

--- a/src/components/profile/team.tsx
+++ b/src/components/profile/team.tsx
@@ -20,7 +20,9 @@ export default function Team({
   activePlayerId,
 }: IProps) {
   return (
-    <div className={`grid grid-cols-[3fr,1fr,3fr] gap-1 ${className}`}>
+    <div
+      className={`flex flex-col flex-wrap sm:grid sm:grid-cols-[3fr,1fr,3fr] gap-1 ${className}`}
+    >
       {teams.map((team: TeamResult, i) => (
         <React.Fragment key={`team-${team.teamid}-${i}`}>
           <div className="flex flex-col gap-1">
@@ -36,7 +38,7 @@ export default function Team({
             ))}
           </div>
           {i === 0 && (
-            <div className="hidden md:flex flex-col align-middle justify-center text-center">
+            <div className=" md:flex flex-col align-middle justify-center text-center">
               x
             </div>
           )}


### PR DESCRIPTION
![192 168 0 127_3000_profile_1073743143 Overview (2024-09-29 14 36 40)](https://github.com/user-attachments/assets/8b28bdee-5e3e-442a-a60c-9172bd9c160b)
![192 168 0 127_3000_profile_1073743143 Overview (2024-09-29 14 36 58)](https://github.com/user-attachments/assets/11bf87d1-091b-46ed-a1bd-78940f21720a)


This should remove the x axis scrolling on mobile (besides for the gods table)