### PR TITLE
feat: persistence of searchParams for leaderboard

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import RedditFeed from "@/components/reddit-feed";
 import { Metadata } from "next";
 import TopRecordedGames from "@/components/recs/top-recorded-games";
 import BannerAd from "@/components/ads/bannerAd";
+import { Suspense } from "react";
 
 export const metadata: Metadata = {
   title: "Home - AoM.gg",
@@ -34,7 +35,9 @@ export default function Home() {
         <div className="flex-1">
           <div className="grid grid-cols-1 xl:grid-cols-4 gap-5">
             <div className="xl:col-span-3">
-              <Leaderboard />
+              <Suspense>
+                <Leaderboard />
+              </Suspense>
             </div>
             <div className="xl:col-span-1 space-y-4">
               <FeaturedYoutubeVideos />

--- a/src/components/data-table-pagination.tsx
+++ b/src/components/data-table-pagination.tsx
@@ -7,6 +7,9 @@ import {
 import { Table } from "@tanstack/react-table";
 
 import { Button } from "@/components/ui/button";
+import { useQueryParams } from "@/hooks/useQueryParams";
+import { useSearchParams } from "next/navigation";
+import { useEffect } from "react";
 
 interface DataTablePaginationProps<TData> {
   table: Table<TData>;
@@ -15,6 +18,20 @@ interface DataTablePaginationProps<TData> {
 export function DataTablePagination<TData>({
   table,
 }: DataTablePaginationProps<TData>) {
+  const rowOptions = [50, 100, 200]
+
+  const searchParams = useSearchParams();
+  const rows = searchParams.get("rows");
+  const queryParams = useQueryParams({ rows: "50" });
+
+  useEffect(() => {
+    if (rowOptions.includes(Number(rows))) {
+      table.setPageSize(Number(rows))
+      return
+    }
+    table.setPageSize(rowOptions[0])
+  }, []);
+
   return (
     <div className="flex px-2">
       {/* Left-aligned content */}
@@ -26,9 +43,10 @@ export function DataTablePagination<TData>({
             value={table.getState().pagination.pageSize}
             onChange={(e) => {
               table.setPageSize(Number(e.target.value));
+              queryParams.rows(e.target.value);
             }}
           >
-            {[50, 100, 200].map((pageSize) => (
+            {rowOptions.map((pageSize) => (
               <option
                 className="font-normal text-base"
                 key={pageSize}

--- a/src/components/filters/date-build-patch-filter.tsx
+++ b/src/components/filters/date-build-patch-filter.tsx
@@ -17,7 +17,7 @@ export default function DateBuildPatchFilter({
   function getValue(build: Build) {
     return build.buildNumber.toString();
   }
-  console.log("filterOptions", filterOptions);
+
   return (
     <SelectFilter
       data={builds}

--- a/src/hooks/useQueryParams.tsx
+++ b/src/hooks/useQueryParams.tsx
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import { useRouter } from 'next/navigation';
+
+
+type QueryParams<T extends Record<string, string>> = {
+  [K in keyof T]: (value: T[K]) => void;
+};
+
+export const useQueryParams = <T extends Record<string, string>>(params: T): QueryParams<T> => {
+  const router = useRouter();
+
+  return useMemo(() => {
+    return Object.keys(params).reduce((acc, key) => {
+      acc[key as keyof T] = (value: T[keyof T]) => {
+        const searchParams = new URLSearchParams(window.location.search);
+        searchParams.set(key, value);
+        let newUrl = `${window.location.pathname}?${searchParams.toString()}`;
+        if (value === '') {
+            newUrl = newUrl.replace(`?${key}=`, '').replace(`&${key}=`, '').replace(`&${key}`, '').replace(`?${key}`, '');
+        }
+        window.history.replaceState(null, '', newUrl);
+      };
+
+      return acc;
+    }, {} as QueryParams<T>);
+  }, [params, router]);
+};


### PR DESCRIPTION
Added queryParams to leaderboard homepage (https://github.com/erin-fitzpatric/next-aom-gg/issues/132)

How to test:

1. Go to homepage
2. Change filters such as 1v1 supremacy, 50 rows per page, search input or page change
3. Confirm that the queryParams are changing in the url
4. Refresh page
5. Confirm that the initialState is correct and behaving as expected based on the queryParams in the URL