### PR TITLE
Recparser: fix breakage from Arena of the Gods update

### DIFF
--- a/src/server/recParser/gameCommands.ts
+++ b/src/server/recParser/gameCommands.ts
@@ -87,7 +87,7 @@ const commandRefiners: Record<number, GameCommandRefiner> = {
     },
     4: {
         type: "setGatherPoint",
-        parseFunctions: [unpackInt32, unpackInt32, unpackVector, unpackFloat, unpackInt32],
+        parseFunctions: [unpackInt32, unpackInt32, unpackVector, unpackFloat, unpackInt32, unpackInt32],
         refinerFunction: (base: any, raw) => {
             base.sourceUnits = raw.sourceUnits;
             base.countsForCPM = false;
@@ -477,7 +477,7 @@ function parseRawGameCommand(view: DataView, offset: number): RawGameCommand
     for (let i=0; i<numPreArgumentBytes; i++)
         preArgumentBytes.push(view.getUint8(offset+i))
     offset += numPreArgumentBytes;
-
+    //console.log(`Before args at ${offset}`);
     const refiner = getCommandRefiner(commandType, offset);
     const argList: RawGameCommandArgumentTypes[] = [];
     for (const parseFunctionData of refiner.parseFunctions)

--- a/src/types/recParser/RecordedGameParser.ts
+++ b/src/types/recParser/RecordedGameParser.ts
@@ -104,7 +104,8 @@ export const RecordedGameRawKeysToCamelCase = new Map<string, string>([
     ["gameismpcoop", "gameIsMpCoop"],
     ["gamemaprecommendedsettings", "gameMapRecommendedSettings"],
     ["gamearenaseason", "gameArenaSeason"],
-    ["usedenforcedagesettings", "usedEnforcedAgeSettings"]
+    ["usedenforcedagesettings", "usedEnforcedAgeSettings"],
+    ["gamecontrolleronly", "gameControllerOnly"],
 ]);
 
 // These arrays define the type and required/optional-ness of the final interfaces
@@ -279,6 +280,7 @@ export const RecordedGameMetadataBooleansRequired = [
 
 export const RecordedGameMetadataBooleansOptional = [
     "commandParserGeneratedWarnings",
+    "gameControllerOnly",
 ] as const;
 
 export interface RecordedGameMetadata extends Record<typeof RecordedGameMetadataStringsRequired[number], string>,
@@ -381,5 +383,8 @@ Version notes:
             added commandParserWarnings
             added commandParserGeneratedWarnings
             added unresignedPlayers
+
+    3:
+        add gameControllerOnly
 
 */


### PR DESCRIPTION
The arena of the gods update broke things in two ways:

1. It added the new key `gamecontrolleronly` which was after `gamesyncstate`. I didn't know the length of `gamesyncstate`'s datatype before which had me write in an error throw if this ever happened.
2. The setGatherPoint command got an extra 4 byte arg added. I don't know what it is, or what it does. This means that command list parsing of older build recs will now throw an error.

Anyway, this hopefully fixes that and exposes the new field.