### PR TITLE
Hopeful fix to rec parser for game ver 17.64528

### DIFF
--- a/src/server/recParser/hierarchy.ts
+++ b/src/server/recParser/hierarchy.ts
@@ -44,7 +44,7 @@ import { RecordedGameHierarchyData, RecordedGameHierarchyContainer, RecordedGame
 import { Errors } from "@/utils/errors";
 
 const MAX_SCAN_LENGTH = 50;
-const OUTER_HIERARCHY_START_OFFSET = 0x101;
+const OUTER_HIERARCHY_START_OFFSET = 0;
 
 interface ParseHierarchyDataOptions
 {

--- a/src/types/recParser/GameCommands.ts
+++ b/src/types/recParser/GameCommands.ts
@@ -5,9 +5,9 @@ export type RawGameCommandArgumentTypes = string | number | Vector3 | boolean;
 
 export interface RawGameCommandFooter
 {
-    early: ArrayBuffer
-    extraBytes: number[]
-    late: ArrayBuffer
+    early: ArrayBuffer | SharedArrayBuffer
+    extraBytes: number[] 
+    late: ArrayBuffer | SharedArrayBuffer
     offsetEnd: number
 }
 
@@ -16,7 +16,7 @@ export interface RawGameCommand
     /**
      * In most cases, first 10 bytes of the command structure. For ungarrison actions (14) this section is 30 bytes long instead for some reason.
      */
-    tenBytes: ArrayBuffer
+    tenBytes: ArrayBuffer | SharedArrayBuffer
     /**
      * The command type (internal enum) issued by this command
      */


### PR DESCRIPTION
Technical stuff, for the sake of documenting this somewhere:

Before the update, both the command list AND hierarchy were bundled together in the l33t-zlib data packed end-to-end, and this data collection was right at the start of the .mythrec file. Now the .mythrec has some extra header and only the hierarchy is l33t-zlib compressed - and the command list is some ~50 bytes after the compressed hierarchy data (which unfortunately necessitates searching for the start of it, a step which could maybe break if extremely unlucky). This meant finding a new way to tell the end of the command list apart from whatever is after it - thankfully offset 0x17 into the raw .mythrec file seems to contain this.