### PR TITLE
Prevent flashing by updating recs only after fetch completion

### DIFF
--- a/src/components/recs/filters/rec-search.tsx
+++ b/src/components/recs/filters/rec-search.tsx
@@ -24,11 +24,10 @@ export default function RecSearch({
   useEffect(() => {
     const fetchRecs = async () => {
       setIsLoading(true);
-      setRecs([]);
+      // Fetch new records before clearing the old ones to prevent flashing
       const recs = await getMythRecs(0, filters);
-      if (recs) {
-        setRecs(recs);
-      }
+      // Only update the records once we have the new data
+      setRecs(recs || []);
       setIsLoading(false);
     };
 


### PR DESCRIPTION
Previously, the records list was cleared before fetching new data, causing a visual flash. This change ensures new records are fetched first and only then replaces the old data, reducing unnecessary UI flicker.